### PR TITLE
Add micrometer prometheus

### DIFF
--- a/3rd-party-config/prometheus/prometheus.yml
+++ b/3rd-party-config/prometheus/prometheus.yml
@@ -1,0 +1,35 @@
+# my global config
+global:
+  scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+          # - alertmanager:9093
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  # - "first_rules.yml"
+  # - "second_rules.yml"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: "prometheus"
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: 'spring boot scrape'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:8080']

--- a/pom.xml
+++ b/pom.xml
@@ -38,11 +38,19 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-boot-starter</artifactId>
 			<version>3.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<version>1.8.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.5.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.scottlogic.practice</groupId>
@@ -21,7 +21,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-rest</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>

--- a/src/main/java/com/scottlogic/practice/mealscheduler/Configs/MetricsConfiguration.java
+++ b/src/main/java/com/scottlogic/practice/mealscheduler/Configs/MetricsConfiguration.java
@@ -1,0 +1,32 @@
+package com.scottlogic.practice.mealscheduler.Configs;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.springframework.context.annotation.Bean;
+
+public class MetricsConfiguration {
+
+    @Bean
+    public PrometheusConfig getMeterRegistryConfig() {
+        return new PrometheusConfig() {
+            @Override
+            public String get(String s) {
+                return null;
+            }
+
+            @Override
+            public String prefix() {
+                return "meal_scheduler";
+            }
+        };
+    }
+
+    @Bean
+    public MeterRegistry getMeterRegistry(PrometheusConfig prometheusConfig) {
+        final var reg = new PrometheusMeterRegistry(prometheusConfig);
+        Metrics.addRegistry(reg);
+        return new PrometheusMeterRegistry(prometheusConfig);
+    }
+}

--- a/src/main/java/com/scottlogic/practice/mealscheduler/Configs/SwaggerConfig.java
+++ b/src/main/java/com/scottlogic/practice/mealscheduler/Configs/SwaggerConfig.java
@@ -1,11 +1,25 @@
 package com.scottlogic.practice.mealscheduler.Configs;
 
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.actuate.endpoint.ExposableEndpoint;
+import org.springframework.boot.actuate.endpoint.web.*;
+import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.servlet.WebMvcEndpointHandlerMapping;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -16,5 +30,35 @@ public class SwaggerConfig {
                 .apis(RequestHandlerSelectors.any())
                 .paths(PathSelectors.any())
                 .build();
+    }
+
+    /* An ugly workaround to make Spring 2.6 work with springfox 3.0
+       Please read more about their bug here: https://github.com/springfox/springfox/issues/3462
+     */
+    @Bean
+    public WebMvcEndpointHandlerMapping webEndpointServletHandlerMapping(WebEndpointsSupplier webEndpointsSupplier,
+                                                                         ServletEndpointsSupplier servletEndpointsSupplier,
+                                                                         ControllerEndpointsSupplier controllerEndpointsSupplier,
+                                                                         EndpointMediaTypes endpointMediaTypes,
+                                                                         CorsEndpointProperties corsProperties,
+                                                                         WebEndpointProperties webEndpointProperties,
+                                                                         Environment environment) {
+        List<ExposableEndpoint<?>> allEndpoints = new ArrayList();
+        Collection<ExposableWebEndpoint> webEndpoints = webEndpointsSupplier.getEndpoints();
+        allEndpoints.addAll(webEndpoints);
+        allEndpoints.addAll(servletEndpointsSupplier.getEndpoints());
+        allEndpoints.addAll(controllerEndpointsSupplier.getEndpoints());
+        String basePath = webEndpointProperties.getBasePath();
+        EndpointMapping endpointMapping = new EndpointMapping(basePath);
+        boolean shouldRegisterLinksMapping = this.shouldRegisterLinksMapping(webEndpointProperties, environment, basePath);
+
+        return new WebMvcEndpointHandlerMapping(endpointMapping, webEndpoints, endpointMediaTypes,
+                corsProperties.toCorsConfiguration(), new EndpointLinksResolver(allEndpoints, basePath),
+                shouldRegisterLinksMapping, null);
+    }
+
+
+    private boolean shouldRegisterLinksMapping(WebEndpointProperties webEndpointProperties, Environment environment, String basePath) {
+        return webEndpointProperties.getDiscovery().isEnabled() && (StringUtils.hasText(basePath) || ManagementPortType.get(environment).equals(ManagementPortType.DIFFERENT));
     }
 }

--- a/src/main/java/com/scottlogic/practice/mealscheduler/Configs/SwaggerConfig.java
+++ b/src/main/java/com/scottlogic/practice/mealscheduler/Configs/SwaggerConfig.java
@@ -1,25 +1,12 @@
 package com.scottlogic.practice.mealscheduler.Configs;
 
-import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
-import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
-import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
-import org.springframework.boot.actuate.endpoint.ExposableEndpoint;
-import org.springframework.boot.actuate.endpoint.web.*;
-import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpointsSupplier;
-import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpointsSupplier;
-import org.springframework.boot.actuate.endpoint.web.servlet.WebMvcEndpointHandlerMapping;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
-import org.springframework.util.StringUtils;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -30,35 +17,5 @@ public class SwaggerConfig {
                 .apis(RequestHandlerSelectors.any())
                 .paths(PathSelectors.any())
                 .build();
-    }
-
-    /* An ugly workaround to make Spring 2.6 work with springfox 3.0
-       Please read more about their bug here: https://github.com/springfox/springfox/issues/3462
-     */
-    @Bean
-    public WebMvcEndpointHandlerMapping webEndpointServletHandlerMapping(WebEndpointsSupplier webEndpointsSupplier,
-                                                                         ServletEndpointsSupplier servletEndpointsSupplier,
-                                                                         ControllerEndpointsSupplier controllerEndpointsSupplier,
-                                                                         EndpointMediaTypes endpointMediaTypes,
-                                                                         CorsEndpointProperties corsProperties,
-                                                                         WebEndpointProperties webEndpointProperties,
-                                                                         Environment environment) {
-        List<ExposableEndpoint<?>> allEndpoints = new ArrayList();
-        Collection<ExposableWebEndpoint> webEndpoints = webEndpointsSupplier.getEndpoints();
-        allEndpoints.addAll(webEndpoints);
-        allEndpoints.addAll(servletEndpointsSupplier.getEndpoints());
-        allEndpoints.addAll(controllerEndpointsSupplier.getEndpoints());
-        String basePath = webEndpointProperties.getBasePath();
-        EndpointMapping endpointMapping = new EndpointMapping(basePath);
-        boolean shouldRegisterLinksMapping = this.shouldRegisterLinksMapping(webEndpointProperties, environment, basePath);
-
-        return new WebMvcEndpointHandlerMapping(endpointMapping, webEndpoints, endpointMediaTypes,
-                corsProperties.toCorsConfiguration(), new EndpointLinksResolver(allEndpoints, basePath),
-                shouldRegisterLinksMapping, null);
-    }
-
-
-    private boolean shouldRegisterLinksMapping(WebEndpointProperties webEndpointProperties, Environment environment, String basePath) {
-        return webEndpointProperties.getDiscovery().isEnabled() && (StringUtils.hasText(basePath) || ManagementPortType.get(environment).equals(ManagementPortType.DIFFERENT));
     }
 }

--- a/src/main/java/com/scottlogic/practice/mealscheduler/Configs/SwaggerConfig.java
+++ b/src/main/java/com/scottlogic/practice/mealscheduler/Configs/SwaggerConfig.java
@@ -7,7 +7,6 @@ import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 
-
 @Configuration
 public class SwaggerConfig {
     @Bean

--- a/src/main/java/com/scottlogic/practice/mealscheduler/Controllers/MealController.java
+++ b/src/main/java/com/scottlogic/practice/mealscheduler/Controllers/MealController.java
@@ -2,6 +2,7 @@ package com.scottlogic.practice.mealscheduler.Controllers;
 
 import com.scottlogic.practice.mealscheduler.Models.Meal;
 import com.scottlogic.practice.mealscheduler.Services.MealService;
+import io.micrometer.core.annotation.Timed;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,12 +18,14 @@ public class MealController {
     }
 
     @GetMapping
+    @Timed("GetAllMeals")
     public List<Meal> GetAllMeals() {
         return mealService.GetAllMeals();
     }
 
     @PostMapping
     @ResponseBody
+    @Timed("CreateMeal")
     public Meal CreateMeal(@RequestBody Meal meal) {
         return mealService.CreateMeal(meal);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,3 +23,6 @@ spring:
   h2:
     console:
       enabled: true
+
+
+management.endpoints.web.exposure.include: health,info,prometheus


### PR DESCRIPTION
This PR adds the support for Micrometer based metrics exposure to prometheus.

Prometheus installation:
1. Download prometheus from: https://prometheus.io/download/
2. Overwrite prometheus.yml from the package with the one from this PR

Grafana installation:
Download Grafana from@ https://grafana.com/grafana/downloadand install grafana

Additionally this PR contains an ugly workaround for a springfox3-spring2.6 cooperation bug: https://github.com/springfox/springfox/issues/3462
that was exposed by adding actuator endpoint (for prometheus).

Should out-of the box be able to produce live charts like:
![image](https://user-images.githubusercontent.com/51954309/159893239-a562c809-8849-441e-b164-ef60401ae1d5.png)

